### PR TITLE
Embedding

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -15,7 +15,7 @@
  *
  */
 
-package main
+package bootstrap
 
 import (
 	"context"
@@ -34,7 +34,6 @@ import (
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	"stash.kopano.io/kgol/rndm"
 
 	"stash.kopano.io/kc/konnect/config"
@@ -59,12 +58,48 @@ const (
 	apiTypeSignin  = "signin"
 )
 
-// bootstrap is a data structure to hold configuration required to start
-// konnectd.
-type bootstrap struct {
-	cmd  *cobra.Command
-	args []string
+// Defaults.
+const (
+	defaultSigningKeyID   = "default"
+	defaultSigningKeyBits = 2048
+)
 
+// Config is a typed application config which represents the user accessible config params
+type Config struct {
+	Iss                            string
+	IdentityManager                string
+	URIBasePath                    string
+	SignInURI                      string
+	SignedOutURI                   string
+	AuthorizationEndpointURI       string
+	EndsessionEndpointURI          string
+	Insecure                       bool
+	TrustedProxy                   []string
+	AllowScope                     []string
+	AllowClientGuests              bool
+	AllowDynamicClientRegistration bool
+	EncryptionSecretFile           string
+	Listen                         string
+	IdentifierClientPath           string
+	IdentifierRegistrationConf     string
+	IdentifierScopesConf           string
+	SigningKid                     string
+	SigningMethod                  string
+	SigningPrivateKeyFiles         []string
+	ValidationKeysPath             string
+	CookieBackendURI               string
+	CookieNames                    []string
+}
+
+// Bootstrap is a data structure to hold configuration required to start
+// konnectd.
+type Bootstrap interface {
+	Config() *config.Config
+	Managers() *managers.Managers
+}
+
+// Implementation of the bootstrap interface
+type bootstrap struct {
 	signInFormURI            *url.URL
 	signedOutURI             *url.URL
 	authorizationEndpointURI *url.URL
@@ -91,7 +126,21 @@ type bootstrap struct {
 	managers *managers.Managers
 }
 
-func init() {
+// Config returns the server configuration
+func (bs *bootstrap) Config() *config.Config {
+	return bs.cfg
+}
+
+// Managers returns bootstrapped identity-managers
+func (bs *bootstrap) Managers() *managers.Managers {
+	return bs.managers
+}
+
+// Boot is the main entry point to  bootstrap the konnectd service after validating the given configuration. The resulting
+// Bootstrap struct can be used to retrieve configured identity-managers and their respective http-handlers and config.
+//
+// This function should be used by consumers which want to embed konnect as a library.
+func Boot(ctx context.Context, bsConf *Config, serverConf *config.Config) (Bootstrap, error) {
 	// NOTE(longsleep): Ensure to use same salt length as the hash size.
 	// See https://www.ietf.org/mail-archive/web/jose/current/msg02901.html for
 	// reference and https://github.com/dgrijalva/jwt-go/issues/285 for
@@ -102,24 +151,38 @@ func init() {
 			signingMethodRSAPSS.Options.SaltLength = rsa.PSSSaltLengthEqualsHash
 		}
 	}
+
+	bs := &bootstrap{
+		cfg: serverConf,
+	}
+
+	err := bs.initialize(bsConf)
+	if err != nil {
+		return nil, err
+	}
+
+	err = bs.setup(ctx, bsConf)
+	if err != nil {
+		return nil, err
+	}
+
+	return bs, nil
 }
 
 // initialize, parsed parameters from commandline with validation and adds them
-// to the accociated bootstrap data.
-func (bs *bootstrap) initialize() error {
-	cmd := bs.cmd
+// to the associated Bootstrap data.
+func (bs *bootstrap) initialize(cfg *Config) error {
 	logger := bs.cfg.Logger
 	var err error
 
-	if len(bs.args) == 0 {
+	if cfg.IdentityManager == "" {
 		return fmt.Errorf("identity-manager argument missing, use one of kc, ldap, cookie, dummy")
 	}
 
-	issuerIdentifier, _ := cmd.Flags().GetString("iss")
-	bs.issuerIdentifierURI, err = url.Parse(issuerIdentifier)
+	bs.issuerIdentifierURI, err = url.Parse(cfg.Iss)
 	if err != nil {
 		return fmt.Errorf("invalid iss value, iss is not a valid URL), %v", err)
-	} else if issuerIdentifier == "" {
+	} else if cfg.Iss == "" {
 		return fmt.Errorf("missing iss value, did you provide the --iss parameter?")
 	} else if bs.issuerIdentifierURI.Scheme != "https" {
 		return fmt.Errorf("invalid iss value, URL must start with https://")
@@ -127,34 +190,29 @@ func (bs *bootstrap) initialize() error {
 		return fmt.Errorf("invalid iss value, URL must have a host")
 	}
 
-	bs.uriBasePath, _ = cmd.Flags().GetString("uri-base-path")
+	bs.uriBasePath = cfg.URIBasePath
 
-	signInFormURIString, _ := cmd.Flags().GetString("sign-in-uri")
-	bs.signInFormURI, err = url.Parse(signInFormURIString)
+	bs.signInFormURI, err = url.Parse(cfg.SignInURI)
 	if err != nil {
 		return fmt.Errorf("invalid sign-in URI, %v", err)
 	}
 
-	signedOutURIString, _ := cmd.Flags().GetString("signed-out-uri")
-	bs.signedOutURI, err = url.Parse(signedOutURIString)
+	bs.signedOutURI, err = url.Parse(cfg.SignedOutURI)
 	if err != nil {
 		return fmt.Errorf("invalid signed-out URI, %v", err)
 	}
 
-	authorizationEndpointURIString, _ := cmd.Flags().GetString("authorization-endpoint-uri")
-	bs.authorizationEndpointURI, err = url.Parse(authorizationEndpointURIString)
+	bs.authorizationEndpointURI, err = url.Parse(cfg.AuthorizationEndpointURI)
 	if err != nil {
 		return fmt.Errorf("invalid authorization-endpoint-uri, %v", err)
 	}
 
-	endSessionEndpointURIString, _ := cmd.Flags().GetString("endsession-endpoint-uri")
-	bs.endSessionEndpointURI, err = url.Parse(endSessionEndpointURIString)
+	bs.endSessionEndpointURI, err = url.Parse(cfg.EndsessionEndpointURI)
 	if err != nil {
 		return fmt.Errorf("invalid endsession-endpoint-uri, %v", err)
 	}
 
-	tlsInsecureSkipVerify, _ := cmd.Flags().GetBool("insecure")
-	if tlsInsecureSkipVerify {
+	if cfg.Insecure {
 		// NOTE(longsleep): This disable http2 client support. See https://github.com/golang/go/issues/14275 for reasons.
 		bs.tlsClientConfig = utils.InsecureSkipVerifyTLSConfig()
 		logger.Warnln("insecure mode, TLS client connections are susceptible to man-in-the-middle attacks")
@@ -162,8 +220,7 @@ func (bs *bootstrap) initialize() error {
 		bs.tlsClientConfig = utils.DefaultTLSConfig()
 	}
 
-	trustedProxies, _ := cmd.Flags().GetStringArray("trusted-proxy")
-	for _, trustedProxy := range trustedProxies {
+	for _, trustedProxy := range cfg.TrustedProxy {
 		if ip := net.ParseIP(trustedProxy); ip != nil {
 			bs.cfg.TrustedProxyIPs = append(bs.cfg.TrustedProxyIPs, &ip)
 			continue
@@ -180,26 +237,23 @@ func (bs *bootstrap) initialize() error {
 		logger.Infoln("trusted proxy networks", bs.cfg.TrustedProxyNets)
 	}
 
-	allowedScopes, _ := cmd.Flags().GetStringArray("allow-scope")
-	if len(allowedScopes) > 0 {
-		bs.cfg.AllowedScopes = allowedScopes
+	if len(cfg.AllowScope) > 0 {
+		bs.cfg.AllowedScopes = cfg.AllowScope
 		logger.Infoln("using custom allowed OAuth 2 scopes", bs.cfg.AllowedScopes)
 	}
 
-	bs.cfg.AllowClientGuests, _ = cmd.Flags().GetBool("allow-client-guests")
+	bs.cfg.AllowClientGuests = cfg.AllowClientGuests
 	if bs.cfg.AllowClientGuests {
 		logger.Infoln("client controlled guests are enabled")
 	}
 
-	bs.cfg.AllowDynamicClientRegistration, _ = cmd.Flags().GetBool("allow-dynamic-client-registration")
+	bs.cfg.AllowDynamicClientRegistration = cfg.AllowDynamicClientRegistration
 	if bs.cfg.AllowDynamicClientRegistration {
 		logger.Infoln("dynamic client registration is enabled")
 	}
 
-	encryptionSecretFn, _ := cmd.Flags().GetString("encryption-secret")
-	if encryptionSecretFn == "" {
-		encryptionSecretFn = os.Getenv("KONNECTD_ENCRYPTION_SECRET")
-	}
+	encryptionSecretFn := cfg.EncryptionSecretFile
+
 	if encryptionSecretFn != "" {
 		logger.WithField("file", encryptionSecretFn).Infoln("loading encryption secret from file")
 		bs.encryptionSecret, err = ioutil.ReadFile(encryptionSecretFn)
@@ -214,23 +268,11 @@ func (bs *bootstrap) initialize() error {
 		bs.encryptionSecret = rndm.GenerateRandomBytes(encryption.KeySize)
 	}
 
-	bs.cfg.ListenAddr, _ = cmd.Flags().GetString("listen")
-	if bs.cfg.ListenAddr == "" {
-		bs.cfg.ListenAddr = os.Getenv("KONNECTD_LISTEN")
-	}
-	if bs.cfg.ListenAddr == "" {
-		bs.cfg.ListenAddr = defaultListenAddr
-	}
+	bs.cfg.ListenAddr = cfg.Listen
 
-	bs.identifierClientPath, _ = cmd.Flags().GetString("identifier-client-path")
-	if bs.identifierClientPath == "" {
-		bs.identifierClientPath = os.Getenv("KONNECTD_IDENTIFIER_CLIENT_PATH")
-	}
-	if bs.identifierClientPath == "" {
-		bs.identifierClientPath = defaultIdentifierClientPath
-	}
+	bs.identifierClientPath = cfg.IdentifierClientPath
 
-	bs.identifierRegistrationConf, _ = cmd.Flags().GetString("identifier-registration-conf")
+	bs.identifierRegistrationConf = cfg.IdentifierRegistrationConf
 	if bs.identifierRegistrationConf != "" {
 		bs.identifierRegistrationConf, _ = filepath.Abs(bs.identifierRegistrationConf)
 		if _, errStat := os.Stat(bs.identifierRegistrationConf); errStat != nil {
@@ -239,7 +281,7 @@ func (bs *bootstrap) initialize() error {
 		bs.identifierAuthoritiesConf = bs.identifierRegistrationConf
 	}
 
-	bs.identifierScopesConf, _ = cmd.Flags().GetString("identifier-scopes-conf")
+	bs.identifierScopesConf = cfg.IdentifierScopesConf
 	if bs.identifierScopesConf != "" {
 		bs.identifierScopesConf, _ = filepath.Abs(bs.identifierScopesConf)
 		if _, errStat := os.Stat(bs.identifierScopesConf); errStat != nil {
@@ -247,29 +289,17 @@ func (bs *bootstrap) initialize() error {
 		}
 	}
 
-	bs.signingKeyID, _ = cmd.Flags().GetString("signing-kid")
-	if bs.signingKeyID == "" {
-		bs.signingKeyID = os.Getenv("KONNECTD_SIGNING_KID")
-	}
-
+	bs.signingKeyID = cfg.SigningKid
 	bs.signers = make(map[string]crypto.Signer)
 	bs.validators = make(map[string]crypto.PublicKey)
 
-	signingMethodString, _ := cmd.Flags().GetString("signing-method")
+	signingMethodString := cfg.SigningMethod
 	bs.signingMethod = jwt.GetSigningMethod(signingMethodString)
 	if bs.signingMethod == nil {
 		return fmt.Errorf("unknown signing method: %s", signingMethodString)
 	}
 
-	signingKeyFns, _ := cmd.Flags().GetStringArray("signing-private-key")
-	if len(signingKeyFns) == 0 {
-		for _, keyFn := range strings.Split(os.Getenv("KONNECTD_SIGNING_PRIVATE_KEY"), " ") {
-			keyFn = strings.TrimSpace(keyFn)
-			if keyFn != "" {
-				signingKeyFns = append(signingKeyFns, keyFn)
-			}
-		}
-	}
+	signingKeyFns := cfg.SigningPrivateKeyFiles
 	if len(signingKeyFns) > 0 {
 		first := true
 		for _, signingKeyFn := range signingKeyFns {
@@ -302,10 +332,7 @@ func (bs *bootstrap) initialize() error {
 		return err
 	}
 
-	validationKeysPath, _ := cmd.Flags().GetString("validation-keys-path")
-	if validationKeysPath == "" {
-		validationKeysPath = os.Getenv("KONNECTD_VALIDATION_KEYS_PATH")
-	}
+	validationKeysPath := cfg.ValidationKeysPath
 	if validationKeysPath != "" {
 		logger.WithField("path", validationKeysPath).Infoln("loading validation keys")
 		err = addValidatorsFromPath(validationKeysPath, bs)
@@ -315,21 +342,20 @@ func (bs *bootstrap) initialize() error {
 	}
 
 	bs.cfg.HTTPTransport = utils.HTTPTransportWithTLSClientConfig(bs.tlsClientConfig)
-
 	bs.accessTokenDurationSeconds = 10 * 60 // 10 Minutes.
 
 	return nil
 }
 
-// setup takes care of setting up the managers based on the accociated
-// bootstrap's data.
-func (bs *bootstrap) setup(ctx context.Context) error {
+// setup takes care of setting up the managers based on the associated
+// Bootstrap's data.
+func (bs *bootstrap) setup(ctx context.Context, cfg *Config) error {
 	managers, err := newManagers(ctx, bs)
 	if err != nil {
 		return err
 	}
 
-	identityManager, err := bs.setupIdentity(ctx)
+	identityManager, err := bs.setupIdentity(ctx, cfg)
 	if err != nil {
 		return err
 	}
@@ -376,21 +402,21 @@ func (bs *bootstrap) makeURIPath(api string, subpath string) string {
 	}
 }
 
-func (bs *bootstrap) setupIdentity(ctx context.Context) (identity.Manager, error) {
+func (bs *bootstrap) setupIdentity(ctx context.Context, cfg *Config) (identity.Manager, error) {
 	var err error
 	logger := bs.cfg.Logger
 
-	if len(bs.args) == 0 {
+	if cfg.IdentityManager == "" {
 		return nil, fmt.Errorf("identity-manager argument missing")
 	}
 
-	identityManagerName := bs.args[0]
+	identityManagerName := cfg.IdentityManager
 
 	// Identity manager.
 	var identityManager identity.Manager
 	switch identityManagerName {
 	case identityManagerNameCookie:
-		identityManager, err = newCookieIdentityManager(bs)
+		identityManager, err = newCookieIdentityManager(bs, cfg)
 
 	case identityManagerNameKC:
 		identityManager, err = newKCIdentityManager(bs)

--- a/bootstrap/cookie.go
+++ b/bootstrap/cookie.go
@@ -15,7 +15,7 @@
  *
  */
 
-package main
+package bootstrap
 
 import (
 	"fmt"
@@ -29,7 +29,7 @@ import (
 	identityManagers "stash.kopano.io/kc/konnect/identity/managers"
 )
 
-func newCookieIdentityManager(bs *bootstrap) (identity.Manager, error) {
+func newCookieIdentityManager(bs *bootstrap, cfg *Config) (identity.Manager, error) {
 	logger := bs.cfg.Logger
 
 	if bs.authorizationEndpointURI.EscapedPath() == "" {
@@ -40,10 +40,10 @@ func newCookieIdentityManager(bs *bootstrap) (identity.Manager, error) {
 		return nil, fmt.Errorf("URI path must be absolute")
 	}
 
-	if len(bs.args) < 2 {
+	if cfg.CookieBackendURI == "" {
 		return nil, fmt.Errorf("cookie backend requires the backend URI as argument")
 	}
-	backendURI, backendURIErr := url.Parse(bs.args[1])
+	backendURI, backendURIErr := url.Parse(cfg.CookieBackendURI)
 	if backendURIErr != nil || !backendURI.IsAbs() {
 		if backendURIErr == nil {
 			backendURIErr = fmt.Errorf("URI must have a scheme")
@@ -52,9 +52,9 @@ func newCookieIdentityManager(bs *bootstrap) (identity.Manager, error) {
 	}
 
 	var cookieNames []string
-	if len(bs.args) > 2 {
+	if len(cfg.CookieNames) > 0 {
 		// TODO(longsleep): Add proper usage help.
-		cookieNames = bs.args[2:]
+		cookieNames = cfg.CookieNames
 	}
 
 	identityManagerConfig := &identity.Config{

--- a/bootstrap/dummy.go
+++ b/bootstrap/dummy.go
@@ -15,7 +15,7 @@
  *
  */
 
-package main
+package bootstrap
 
 import (
 	"stash.kopano.io/kc/konnect/identity"

--- a/bootstrap/guest.go
+++ b/bootstrap/guest.go
@@ -15,7 +15,7 @@
  *
  */
 
-package main
+package bootstrap
 
 import (
 	"stash.kopano.io/kc/konnect/identity"

--- a/bootstrap/kc.go
+++ b/bootstrap/kc.go
@@ -15,7 +15,7 @@
  *
  */
 
-package main
+package bootstrap
 
 import (
 	"fmt"

--- a/bootstrap/ldap.go
+++ b/bootstrap/ldap.go
@@ -15,7 +15,7 @@
  *
  */
 
-package main
+package bootstrap
 
 import (
 	"fmt"

--- a/bootstrap/managers.go
+++ b/bootstrap/managers.go
@@ -15,12 +15,11 @@
  *
  */
 
-package main
+package bootstrap
 
 import (
 	"context"
 	"fmt"
-
 	"stash.kopano.io/kc/konnect/managers"
 
 	identityAuthorities "stash.kopano.io/kc/konnect/identity/authorities"

--- a/bootstrap/utils.go
+++ b/bootstrap/utils.go
@@ -1,0 +1,384 @@
+package bootstrap
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"github.com/dgrijalva/jwt-go"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/square/go-jose.v2"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"stash.kopano.io/kc/konnect/signing"
+	"strings"
+)
+
+func parseJSONWebKey(jsonBytes []byte) (*jose.JSONWebKey, error) {
+	k := &jose.JSONWebKey{}
+	if err := k.UnmarshalJSON(jsonBytes); err != nil {
+		return nil, err
+	}
+	return k, nil
+}
+
+// LoadSignerFromFile loads a private-key for signing
+//
+// Supports JSON (JWK/JWS) and PEM
+func LoadSignerFromFile(fn string) (string, crypto.Signer, error) {
+	readBytes, errRead := ioutil.ReadFile(fn)
+	if errRead != nil {
+		return "", nil, fmt.Errorf("failed to parse key file: %v", errRead)
+	}
+
+	ext := filepath.Ext(fn)
+	switch ext {
+	case ".json":
+		k, err := parseJSONWebKey(readBytes)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to parse key file as JWK: %v", err)
+		}
+		if !k.Valid() {
+			return "", nil, fmt.Errorf("json file is not a valid JWK")
+		}
+		if k.IsPublic() {
+			return "", nil, fmt.Errorf("JWK is a public key, private key required to use as signer")
+		}
+		signer, ok := k.Key.(crypto.Signer)
+		if !ok {
+			return "", nil, fmt.Errorf("JWS key type %T is not a signer", k.Key)
+		}
+
+		return k.KeyID, signer, nil
+
+	case ".pem":
+		fallthrough
+	default:
+		// Try PEM if not otherwise detected.
+		signer, err := parsePEMSigner(readBytes)
+		return "", signer, err
+	}
+}
+
+func parsePEMSigner(pemBytes []byte) (crypto.Signer, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found")
+	}
+
+	var signer crypto.Signer
+	for {
+		pkcs1Key, errParse1 := x509.ParsePKCS1PrivateKey(block.Bytes)
+		if errParse1 == nil {
+			signer = pkcs1Key
+			break
+		}
+
+		pkcs8Key, errParse2 := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if errParse2 == nil {
+			signerSigner, ok := pkcs8Key.(crypto.Signer)
+			if !ok {
+				return nil, fmt.Errorf("failed to use key as crypto signer")
+			}
+			signer = signerSigner
+			break
+		}
+
+		ecKey, errParse3 := x509.ParseECPrivateKey(block.Bytes)
+		if errParse3 == nil {
+			signer = ecKey
+			break
+		}
+
+		return nil, fmt.Errorf("failed to parse signer key - valid PKCS#1, PKCS#8 ...? %v, %v, %v", errParse1, errParse2, errParse3)
+	}
+
+	return signer, nil
+}
+
+// LoadValidatorFromFile loads a public-key used for validation.
+//
+// Supported formats are JSON-JWK and PEM
+func LoadValidatorFromFile(fn string) (string, crypto.PublicKey, error) {
+	readBytes, errRead := ioutil.ReadFile(fn)
+	if errRead != nil {
+		return "", nil, fmt.Errorf("failed to parse key file: %v", errRead)
+	}
+
+	ext := filepath.Ext(fn)
+	switch ext {
+	case ".json":
+		k, err := parseJSONWebKey(readBytes)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to parse key file as JWK: %v", err)
+		}
+		if !k.Valid() {
+			return "", nil, fmt.Errorf("json file is not a valid JWK")
+		}
+		if !k.IsPublic() {
+			public := k.Public()
+			k = &public
+		}
+		return k.KeyID, k.Key, nil
+
+	case ".pem":
+		fallthrough
+	default:
+		// Try PEM if not otherwise detected.
+		validator, err := parsePEMValidator(readBytes)
+		return "", validator, err
+	}
+}
+
+func parsePEMValidator(pemBytes []byte) (crypto.PublicKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found")
+	}
+
+	var validator crypto.PublicKey
+	for {
+		pkixPubKey, errParse0 := x509.ParsePKIXPublicKey(block.Bytes)
+		if errParse0 == nil {
+			validator = pkixPubKey
+			break
+		}
+
+		pkcs1PubKey, errParse1 := x509.ParsePKCS1PublicKey(block.Bytes)
+		if errParse1 == nil {
+			validator = pkcs1PubKey
+			break
+		}
+
+		pkcs1PrivKey, errParse2 := x509.ParsePKCS1PrivateKey(block.Bytes)
+		if errParse2 == nil {
+			validator = pkcs1PrivKey.Public()
+			break
+		}
+
+		pkcs8Key, errParse3 := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if errParse3 == nil {
+			signerSigner, ok := pkcs8Key.(crypto.Signer)
+			if !ok {
+				return nil, fmt.Errorf("failed to use key as crypto signer")
+			}
+			validator = signerSigner.Public()
+			break
+		}
+
+		ecKey, errParse4 := x509.ParseECPrivateKey(block.Bytes)
+		if errParse4 == nil {
+			validator = ecKey.Public()
+			break
+		}
+
+		return nil, fmt.Errorf("failed to parse validator key - valid PKCS#1, PKCS#8 ...? %v, %v, %v, %v, %v", errParse0, errParse1, errParse2, errParse3, errParse4)
+	}
+
+	return validator, nil
+}
+
+func addSignerWithIDFromFile(fn string, kid string, bs *bootstrap) error {
+	fi, err := os.Lstat(fn)
+	if err != nil {
+		return fmt.Errorf("failed load load signer key: %v", err)
+	}
+
+	mode := fi.Mode()
+	switch {
+	case mode.IsDir():
+		return fmt.Errorf("signer key must be a file")
+	}
+
+	// Load file.
+	signerKid, signer, err := LoadSignerFromFile(fn)
+	if err != nil {
+		return err
+	}
+	if kid == "" {
+		kid = signerKid
+	}
+	if kid == "" {
+		// Get ID from file, following symbolic link.
+		var real string
+		if mode&os.ModeSymlink != 0 {
+			real, err = os.Readlink(fn)
+			if err != nil {
+				return err
+			}
+			_, real = filepath.Split(real)
+		} else {
+			real = fi.Name()
+		}
+
+		kid = getKeyIDFromFilename(real)
+	}
+
+	if _, ok := bs.signers[kid]; ok {
+		bs.cfg.Logger.WithFields(logrus.Fields{
+			"path": fn,
+			"kid":  kid,
+		}).Warnln("skipped as signer with same kid already loaded")
+		return nil
+	} else {
+		bs.cfg.Logger.WithFields(logrus.Fields{
+			"path": fn,
+			"kid":  kid,
+		}).Debugln("loaded signer key")
+	}
+
+	bs.signers[kid] = signer
+	return nil
+}
+
+func validateSigners(bs *bootstrap) error {
+	haveRSA := false
+	haveECDSA := false
+	haveEd25519 := false
+	for _, signer := range bs.signers {
+		switch s := signer.(type) {
+		case *rsa.PrivateKey:
+			// Ensure the private key is not vulnerable with PKCS-1.5 signatures. See
+			// https://paragonie.com/blog/2018/04/protecting-rsa-based-protocols-against-adaptive-chosen-ciphertext-attacks#rsa-anti-bb98
+			// for details.
+			if s.PublicKey.E < 65537 {
+				return fmt.Errorf("RSA signing key with public exponent < 65537")
+			}
+			haveRSA = true
+		case *ecdsa.PrivateKey:
+			haveECDSA = true
+		case ed25519.PrivateKey:
+			haveEd25519 = true
+		default:
+			return fmt.Errorf("unsupported signer type: %v", s)
+		}
+	}
+
+	// Validate signing method
+	switch bs.signingMethod.(type) {
+	case *jwt.SigningMethodRSA:
+		if !haveRSA {
+			return fmt.Errorf("no private key for signing method: %s", bs.signingMethod.Alg())
+		}
+	case *jwt.SigningMethodRSAPSS:
+		if !haveRSA {
+			return fmt.Errorf("no private key for signing method: %s", bs.signingMethod.Alg())
+		}
+	case *jwt.SigningMethodECDSA:
+		if !haveECDSA {
+			return fmt.Errorf("no private key for signing method: %s", bs.signingMethod.Alg())
+		}
+	case *signing.SigningMethodEdwardsCurve:
+		if !haveEd25519 {
+			return fmt.Errorf("no private key for signing method: %s", bs.signingMethod.Alg())
+		}
+	default:
+		return fmt.Errorf("unsupported signing method: %s", bs.signingMethod.Alg())
+	}
+
+	if !haveRSA {
+		bs.cfg.Logger.Warnln("no RSA signing private key, some clients might not be compatible")
+	}
+
+	return nil
+}
+
+func addValidatorsFromPath(pn string, bs *bootstrap) error {
+	fi, err := os.Lstat(pn)
+	if err != nil {
+		return fmt.Errorf("failed load load validator keys: %v", err)
+	}
+
+	switch mode := fi.Mode(); {
+	case mode.IsDir():
+		// OK.
+	default:
+		return fmt.Errorf("validator path must be a directory")
+	}
+
+	// Load all files.
+	files := []string{}
+	if pemFiles, err := filepath.Glob(filepath.Join(pn, "*.pem")); err != nil {
+		return fmt.Errorf("validator path err: %v", err)
+	} else {
+		files = append(files, pemFiles...)
+	}
+	if jsonFiles, err := filepath.Glob(filepath.Join(pn, "*.json")); err != nil {
+		return fmt.Errorf("validator path err: %v", err)
+	} else {
+		files = append(files, jsonFiles...)
+	}
+
+	for _, file := range files {
+		kid, validator, err := LoadValidatorFromFile(file)
+		if err != nil {
+			bs.cfg.Logger.WithError(err).WithField("path", file).Warnln("failed to load validator key")
+			continue
+		}
+
+		// Get ID from file, without following symbolic links.
+		if kid == "" {
+			_, fn := filepath.Split(file)
+			kid = getKeyIDFromFilename(fn)
+		}
+		if _, ok := bs.validators[kid]; ok {
+			bs.cfg.Logger.WithFields(logrus.Fields{
+				"path": file,
+				"kid":  kid,
+			}).Warnln("skipped as validator with same kid already loaded")
+			continue
+		} else {
+			bs.cfg.Logger.WithFields(logrus.Fields{
+				"path": file,
+				"kid":  kid,
+			}).Debugln("loaded validator key")
+		}
+		bs.validators[kid] = validator
+	}
+
+	return nil
+}
+
+func withSchemeAndHost(u, base *url.URL) *url.URL {
+	if u.Host != "" && u.Scheme != "" {
+		return u
+	}
+
+	r, _ := url.Parse(u.String())
+	r.Scheme = base.Scheme
+	r.Host = base.Host
+
+	return r
+}
+
+func getKeyIDFromFilename(fn string) string {
+	ext := filepath.Ext(fn)
+	return strings.TrimSuffix(fn, ext)
+}
+
+func getCommonURLPathPrefix(p1, p2 string) (string, error) {
+	parts1 := strings.Split(p1, "/")
+	parts2 := strings.Split(p2, "/")
+
+	common := make([]string, 0)
+	for idx, p := range parts1 {
+		if idx >= len(parts2) {
+			break
+		}
+		if p != parts2[idx] {
+			break
+		}
+		common = append(common, p)
+	}
+	if len(common) == 0 {
+		return "", errors.New("no common path prefix")
+	}
+
+	return strings.Join(common, "/"), nil
+}

--- a/cmd/konnectd/env.go
+++ b/cmd/konnectd/env.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 Kopano and its licensors
+ * Copyright 2017-2020 Kopano and its licensors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,21 +18,29 @@
 package main
 
 import (
-	"github.com/spf13/cobra"
 	"os"
+	"strings"
 )
 
-func commandUtils() *cobra.Command {
-	jwkCmd := &cobra.Command{
-		Use:   "utils",
-		Short: "Konnect related utilities",
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
-			os.Exit(2)
-		},
+// envOrDefault returns the value of an env-variable or the default if the env-var is not set
+func envOrDefault(name string, def string) string {
+	v := os.Getenv(name)
+	if v == "" {
+		return def
 	}
 
-	jwkCmd.AddCommand(commandJwkFromPem())
+	return v
+}
 
-	return jwkCmd
+// listEnvArg parses an env-arg which has a space separated list as value
+func listEnvArg(name string) []string {
+	list := make([]string, 0)
+	for _, keyFn := range strings.Split(os.Getenv(name), " ") {
+		keyFn = strings.TrimSpace(keyFn)
+		if keyFn != "" {
+			list = append(list, keyFn)
+		}
+	}
+
+	return list
 }

--- a/cmd/konnectd/jwk.go
+++ b/cmd/konnectd/jwk.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"stash.kopano.io/kc/konnect/bootstrap"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -61,14 +62,14 @@ func jwkFromPem(cmd *cobra.Command, args []string) error {
 	fn := args[0]
 
 	key, err := func() (interface{}, error) {
-		signerKid, signer, err := loadSignerFromFile(fn)
+		signerKid, signer, err := bootstrap.LoadSignerFromFile(fn)
 		if err == nil {
 			if kid == "" {
 				kid = signerKid
 			}
 			return signer, nil
 		}
-		validatorKid, validator, err := loadValidatorFromFile(fn)
+		validatorKid, validator, err := bootstrap.LoadValidatorFromFile(fn)
 		if err == nil {
 			if kid == "" {
 				kid = validatorKid

--- a/cmd/konnectd/main.go
+++ b/cmd/konnectd/main.go
@@ -20,8 +20,13 @@ package main
 import (
 	"fmt"
 	"os"
-
 	"stash.kopano.io/kc/konnect/cmd"
+)
+
+// Defaults.
+const (
+	defaultListenAddr           = "127.0.0.1:8777"
+	defaultIdentifierClientPath = "./identifier-webapp"
 )
 
 func main() {

--- a/server/server.go
+++ b/server/server.go
@@ -56,7 +56,7 @@ func NewServer(c *Config) (*Server, error) {
 	return s, nil
 }
 
-// AddContext adds the accociated server context with cancel to the the provided
+// AddContext adds the associated server context with cancel to the the provided
 // httprouter.Handle. When the handler is done, the per Request context is
 // cancelled.
 func (s *Server) AddContext(parent context.Context, next http.Handler) http.Handler {
@@ -93,7 +93,7 @@ func (s *Server) AddContext(parent context.Context, next http.Handler) http.Hand
 	})
 }
 
-// AddRoutes add the accociated Servers URL routes to the provided router with
+// AddRoutes add the associated Servers URL routes to the provided router with
 // the provided context.Context.
 func (s *Server) AddRoutes(ctx context.Context, router *mux.Router) {
 	// TODO(longsleep): Add subpath support to all handlers and paths.


### PR DESCRIPTION
This PR decouples the boot-configuration of konnectd from the cli to make konnectd embeddable as librarary. 

To achive this bootstrap was moved out of the konnectd cli package. A config struct with all the consumer-facing config options was created [here](https://github.com/Kopano-dev/konnect/blob/71df2c09c310bbd814c1b5258ab41cdcf8d5832b/bootstrap/bootstrap.go#L69). 

All environment and cli dependant code in bootstrap.go was rewritten to only depend on the config object above.

Issue #18 