### PR TITLE
Add disable-identifier-webapp option

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -83,6 +83,7 @@ type Config struct {
 	IdentifierClientPath           string
 	IdentifierRegistrationConf     string
 	IdentifierScopesConf           string
+	IdentifierWebAppDisabled       bool
 	SigningKid                     string
 	SigningMethod                  string
 	SigningPrivateKeyFiles         []string
@@ -109,6 +110,7 @@ type bootstrap struct {
 
 	issuerIdentifierURI        *url.URL
 	identifierClientPath       string
+	identifierWebAppDisabled   bool
 	identifierRegistrationConf string
 	identifierAuthoritiesConf  string
 	identifierScopesConf       string
@@ -271,6 +273,7 @@ func (bs *bootstrap) initialize(cfg *Config) error {
 	bs.cfg.ListenAddr = cfg.Listen
 
 	bs.identifierClientPath = cfg.IdentifierClientPath
+	bs.identifierWebAppDisabled = cfg.IdentifierWebAppDisabled
 
 	bs.identifierRegistrationConf = cfg.IdentifierRegistrationConf
 	if bs.identifierRegistrationConf != "" {

--- a/bootstrap/kc.go
+++ b/bootstrap/kc.go
@@ -132,6 +132,7 @@ func newKCIdentityManager(bs *bootstrap) (identity.Manager, error) {
 		StaticFolder:    bs.identifierClientPath,
 		LogonCookieName: "__Secure-KKT", // Kopano-Konnect-Token
 		ScopesConf:      bs.identifierScopesConf,
+		WebAppDisabled:  bs.identifierWebAppDisabled,
 
 		AuthorizationEndpointURI: fullAuthorizationEndpointURL,
 

--- a/bootstrap/ldap.go
+++ b/bootstrap/ldap.go
@@ -96,6 +96,7 @@ func newLDAPIdentityManager(bs *bootstrap) (identity.Manager, error) {
 		StaticFolder:    bs.identifierClientPath,
 		LogonCookieName: "__Secure-KKT", // Kopano-Konnect-Token
 		ScopesConf:      bs.identifierScopesConf,
+		WebAppDisabled:  bs.identifierWebAppDisabled,
 
 		AuthorizationEndpointURI: fullAuthorizationEndpointURL,
 

--- a/cmd/konnectd/serve.go
+++ b/cmd/konnectd/serve.go
@@ -85,6 +85,7 @@ func commandServe() *cobra.Command {
 	serveCmd.Flags().StringVar(&cfg.AuthorizationEndpointURI, "authorization-endpoint-uri", "", "Custom authorization endpoint URI")
 	serveCmd.Flags().StringVar(&cfg.EndsessionEndpointURI, "endsession-endpoint-uri", "", "Custom endsession endpoint URI")
 	serveCmd.Flags().StringVar(&cfg.IdentifierClientPath, "identifier-client-path", envOrDefault("KONNECTD_IDENTIFIER_CLIENT_PATH", defaultIdentifierClientPath), fmt.Sprintf("Path to the identifier web client base folder (default \"%s\")", defaultIdentifierClientPath))
+	serveCmd.Flags().BoolVar(&cfg.IdentifierWebAppDisabled, "disable-identifier-webapp", false, "Disable the identifier webapp if you want to use a different web-interface.")
 	serveCmd.Flags().StringVar(&cfg.IdentifierRegistrationConf, "identifier-registration-conf", "", "Path to a identifier-registration.yaml configuration file")
 	serveCmd.Flags().StringVar(&cfg.IdentifierScopesConf, "identifier-scopes-conf", "", "Path to a scopes.yaml configuration file")
 	serveCmd.Flags().BoolVar(&cfg.Insecure, "insecure", false, "Disable TLS certificate and hostname validation")

--- a/identifier/config.go
+++ b/identifier/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	StaticFolder    string
 	LogonCookieName string
 	ScopesConf      string
+	WebAppDisabled  bool
 
 	AuthorizationEndpointURI *url.URL
 


### PR DESCRIPTION
Allows to use a different identifier-client, for example one served from elsewhere.