### PR TITLE
Fix openssl rand arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ the Kopano Groupware Core unix socket as admin user `SYSTEM`.
 ### Run Konnect from Docker image
 
 ```
-openssl rand 32 -out /etc/kopano/konnectd-encryption-secret.key
+openssl rand -out /etc/kopano/konnectd-encryption-secret.key 32
 docker run --rm=true --name=konnectd \
 	--read-only \
 	--user=$(id -u kopano):$(id -g kopano) \


### PR DESCRIPTION
At least in my version of openssl the parameter order must be changed.